### PR TITLE
Tweak - Update about page options in Suffice theme

### DIFF
--- a/inc/admin/class-suffice-admin.php
+++ b/inc/admin/class-suffice-admin.php
@@ -92,8 +92,6 @@ if ( ! class_exists( 'Suffice_Admin' ) ) :
 			<p class="suffice-actions">
 				<a href="<?php echo esc_url( 'https://themegrill.com/themes/suffice/?utm_source=suffice-about&utm_medium=theme-info-link&utm_campaign=theme-info' ); ?>" class="button button-secondary" target="_blank"><?php esc_html_e( 'Theme Info', 'suffice' ); ?></a>
 
-				<a href="<?php echo esc_url( 'https://demo.themegrill.com/suffice/' ); ?>" class="button button-secondary docs" target="_blank"><?php esc_html_e( 'View Demo', 'suffice' ); ?></a>
-
 				<a href="<?php echo esc_url( 'https://themegrill.com/themes/suffice/?utm_source=suffice-about&utm_medium=view-pro-link&utm_campaign=view-pro#free-vs-pro' ); ?>" class="button button-primary docs" target="_blank"><?php esc_html_e( 'View PRO version', 'suffice' ); ?></a>
 
 				<a href="<?php echo esc_url( 'https://wordpress.org/support/theme/suffice/reviews?rate=5#new-post' ); ?>" class="button button-secondary docs" target="_blank"><?php esc_html_e( 'Rate this theme', 'suffice' ); ?></a>
@@ -210,13 +208,6 @@ if ( ! class_exists( 'Suffice_Admin' ) ) :
 				<div class="changelog point-releases">
 					<div class="under-the-hood two-col">
 						<div class="col">
-							<h3><?php esc_html_e( 'Import Demo', 'suffice' ); ?></h3>
-							<p><?php esc_html_e( 'Needs ThemeGrill Demo Importer plugin.', 'suffice' ); ?></p>
-							<p>
-								<a href="<?php echo esc_url( network_admin_url( 'plugin-install.php?tab=search&type=term&s=themegrill-demo-importer' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Install', 'suffice' ); ?></a>
-							</p>
-						</div>
-						<div class="col">
 							<h3><?php esc_html_e( 'Theme Customizer', 'suffice' ); ?></h3>
 							<p><?php esc_html_e( 'All Theme Options are available via Customize screen.', 'suffice' ); ?></p>
 							<p>
@@ -237,14 +228,6 @@ if ( ! class_exists( 'Suffice_Admin' ) ) :
 							<p><?php esc_html_e( 'Please put it in our dedicated support forum.', 'suffice' ); ?></p>
 							<p>
 								<a href="<?php echo esc_url( 'https://themegrill.com/support-forum/?utm_source=suffice-about&utm_medium=support-forum-link&utm_campaign=support-forum' ); ?>" class="button button-secondary" target="_blank"><?php esc_html_e( 'Support Forum', 'suffice' ); ?></a>
-							</p>
-						</div>
-
-						<div class="col">
-							<h3><?php esc_html_e( 'Need more features?', 'suffice' ); ?></h3>
-							<p><?php esc_html_e( 'Upgrade to PRO version for more exciting features.', 'suffice' ); ?></p>
-							<p>
-								<a href="<?php echo esc_url( 'https://themegrill.com/themes/suffice/?utm_source=suffice-about&utm_medium=view-pro-link&utm_campaign=view-pro#free-vs-pro' ); ?>" class="button button-secondary" target="_blank"><?php esc_html_e( 'View Pro', 'suffice' ); ?></a>
 							</p>
 						</div>
 

--- a/inc/admin/class-suffice-admin.php
+++ b/inc/admin/class-suffice-admin.php
@@ -92,6 +92,8 @@ if ( ! class_exists( 'Suffice_Admin' ) ) :
 			<p class="suffice-actions">
 				<a href="<?php echo esc_url( 'https://themegrill.com/themes/suffice/?utm_source=suffice-about&utm_medium=theme-info-link&utm_campaign=theme-info' ); ?>" class="button button-secondary" target="_blank"><?php esc_html_e( 'Theme Info', 'suffice' ); ?></a>
 
+				<a href="<?php echo esc_url( 'https://demo.themegrill.com/suffice/' ); ?>" class="button button-secondary docs" target="_blank"><?php esc_html_e( 'View Demo', 'suffice' ); ?></a>
+
 				<a href="<?php echo esc_url( 'https://themegrill.com/themes/suffice/?utm_source=suffice-about&utm_medium=view-pro-link&utm_campaign=view-pro#free-vs-pro' ); ?>" class="button button-primary docs" target="_blank"><?php esc_html_e( 'View PRO version', 'suffice' ); ?></a>
 
 				<a href="<?php echo esc_url( 'https://wordpress.org/support/theme/suffice/reviews?rate=5#new-post' ); ?>" class="button button-secondary docs" target="_blank"><?php esc_html_e( 'Rate this theme', 'suffice' ); ?></a>
@@ -228,14 +230,6 @@ if ( ! class_exists( 'Suffice_Admin' ) ) :
 							<p><?php esc_html_e( 'Please put it in our dedicated support forum.', 'suffice' ); ?></p>
 							<p>
 								<a href="<?php echo esc_url( 'https://themegrill.com/support-forum/?utm_source=suffice-about&utm_medium=support-forum-link&utm_campaign=support-forum' ); ?>" class="button button-secondary" target="_blank"><?php esc_html_e( 'Support Forum', 'suffice' ); ?></a>
-							</p>
-						</div>
-
-						<div class="col">
-							<h3><?php esc_html_e( 'Got sales related question?', 'suffice' ); ?></h3>
-							<p><?php esc_html_e( 'Please send it via our sales contact page.', 'suffice' ); ?></p>
-							<p>
-								<a href="<?php echo esc_url( 'https://themegrill.com/contact/?utm_source=suffice-about&utm_medium=contact-page-link&utm_campaign=contact-page' ); ?>" class="button button-secondary" target="_blank"><?php esc_html_e( 'Contact Page', 'suffice' ); ?></a>
 							</p>
 						</div>
 


### PR DESCRIPTION
# Description
- I've updated the about page options in Suffice theme.
# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Changelog
A changelog is not required.
# Did you test this issue fix on all browsers?
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
# Checklist:
- [x] My code follows the WPCS
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have made perform test that proves my fix is effective or that my feature works